### PR TITLE
Support record deletion

### DIFF
--- a/lib/ncmb.rb
+++ b/lib/ncmb.rb
@@ -3,4 +3,5 @@ $:.unshift(File.dirname(__FILE__))
 require "ncmb/version"
 require "ncmb/client"
 require "ncmb/data_store"
+require "ncmb/object"
 require "ncmb/push"

--- a/lib/ncmb/client.rb
+++ b/lib/ncmb/client.rb
@@ -29,6 +29,10 @@ module NCMB
       request :post, path, params
     end
     
+    def delete(path, params)
+      request :delete, path, {}
+    end
+    
     def array2hash(ary)
       new_v = {}
       ary.each do |hash|
@@ -103,6 +107,9 @@ module NCMB
       if method == :get
         path = path + URI.escape((query == '' ? "" : "?"+query), /[^-_.!~*'()a-zA-Z\d;\/?@&=+$,#]/)
         return JSON.parse(http.get(path, headers).body, symbolize_names: true)
+      elsif method == :delete
+        path = path + URI.escape((query == '' ? "" : "?"+query), /[^-_.!~*'()a-zA-Z\d;\/?@&=+$,#]/)
+        http.delete(path, headers)
       else
         return JSON.parse(http.post(path, queries.to_json, headers).body, symbolize_names: true)
       end

--- a/lib/ncmb/data_store.rb
+++ b/lib/ncmb/data_store.rb
@@ -88,7 +88,7 @@ module NCMB
       results[:results].each do |result|
         alc = result[:acl]
         result.delete(:acl)
-        items << NCMB::DataStore.new(@@name, result, alc)
+        items << NCMB::Object.new(@@name, result, alc)
       end
       @@items = items
     end

--- a/lib/ncmb/object.rb
+++ b/lib/ncmb/object.rb
@@ -1,0 +1,24 @@
+module NCMB
+  class Object
+    include NCMB
+
+    def initialize(name, fields = {}, alc = "")
+      @name    = name
+      @alc     = alc
+      @fields  = fields
+    end
+
+    def method_missing(name)
+      sym = name.to_sym
+      if @fields.has_key?(sym)
+        return @fields[sym]
+      else
+        raise NoMethod, "#{name} is not found"
+      end
+    end
+
+    def [](key)
+      @fields[key]
+    end
+  end
+end

--- a/lib/ncmb/object.rb
+++ b/lib/ncmb/object.rb
@@ -20,5 +20,10 @@ module NCMB
     def [](key)
       @fields[key]
     end
+
+    def delete
+      path = "/#{@@client.api_version}/classes/#{@name}/#{@fields[:objectId]}"
+      @@client.delete path, {}
+    end
   end
 end


### PR DESCRIPTION
Add a method to delete record.

To achieve this,
Create `Object` class which instance represent `DataStore` record
like other environment.

ex.

```ruby
foo = NCMB::DataStore.new('Foo').where({objectId: 'foobarbaz'})
if foo
  foo.delete
end
```
